### PR TITLE
Handle GitCommandError to prevent node loading failures on bad network

### DIFF
--- a/Loader.py
+++ b/Loader.py
@@ -249,6 +249,8 @@ class Loader:
 
             except ImportError:
                 self.__error("GitPython is not installed.")
+            except GitCommandError:
+                self.__error("git command exec failed.")
 
     def setup_rembg(self):
         os.environ["U2NET_HOME"] = folder_paths.models_dir + "/onnx"


### PR DESCRIPTION
The node may fail to load successfully in the event of a poor network connection. To address this, GitCommandError is handled to prevent node loading failures caused by network issues.